### PR TITLE
fix: send null for removed metadata keys on updates

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -43,10 +43,10 @@ type DomainData struct {
 
 // OrganizationUpdateRequest represents the request to update an organization
 type OrganizationUpdateRequest struct {
-	Name       string            `json:"name,omitempty"`
-	DomainData []DomainData      `json:"domain_data,omitempty"`
-	ExternalID string            `json:"external_id,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
+	Name       string             `json:"name,omitempty"`
+	DomainData []DomainData       `json:"domain_data,omitempty"`
+	ExternalID string             `json:"external_id,omitempty"`
+	Metadata   map[string]*string `json:"metadata,omitempty"`
 }
 
 // OrganizationListResponse represents the response from listing organizations
@@ -173,7 +173,7 @@ type UserUpdateRequest struct {
 	LastName      string            `json:"last_name,omitempty"`
 	EmailVerified *bool             `json:"email_verified,omitempty"`
 	ExternalID    string            `json:"external_id,omitempty"`
-	Metadata      map[string]string `json:"metadata,omitempty"`
+	Metadata      map[string]*string `json:"metadata,omitempty"`
 }
 
 // OrganizationMembershipRole represents the role assigned in a membership

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -350,14 +350,33 @@ func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRe
 		updateReq.ExternalID = plan.ExternalID.ValueString()
 	}
 
-	// Add metadata if specified
-	if !plan.Metadata.IsNull() && !plan.Metadata.IsUnknown() {
-		metadata := make(map[string]string)
-		resp.Diagnostics.Append(plan.Metadata.ElementsAs(ctx, &metadata, false)...)
-		if resp.Diagnostics.HasError() {
-			return
+	// WorkOS merges metadata on update — removed keys must be sent as null.
+	if !plan.Metadata.Equal(state.Metadata) && !plan.Metadata.IsUnknown() {
+		updateMap := make(map[string]*string)
+		if !plan.Metadata.IsNull() {
+			newMetadata := make(map[string]string)
+			resp.Diagnostics.Append(plan.Metadata.ElementsAs(ctx, &newMetadata, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for k, v := range newMetadata {
+				v := v
+				updateMap[k] = &v
+			}
 		}
-		updateReq.Metadata = metadata
+		if !state.Metadata.IsNull() && !state.Metadata.IsUnknown() {
+			oldMetadata := make(map[string]string)
+			resp.Diagnostics.Append(state.Metadata.ElementsAs(ctx, &oldMetadata, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for key := range oldMetadata {
+				if _, exists := updateMap[key]; !exists {
+					updateMap[key] = nil
+				}
+			}
+		}
+		updateReq.Metadata = updateMap
 	}
 
 	// Add domains if specified

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -471,12 +471,32 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		updateReq.ExternalID = plan.ExternalID.ValueString()
 	}
 	if !plan.Metadata.Equal(state.Metadata) && !plan.Metadata.IsUnknown() {
-		metadata := make(map[string]string)
-		resp.Diagnostics.Append(plan.Metadata.ElementsAs(ctx, &metadata, false)...)
-		if resp.Diagnostics.HasError() {
-			return
+		// WorkOS merges metadata on update — removed keys must be sent as null.
+		updateMap := make(map[string]*string)
+		if !plan.Metadata.IsNull() {
+			newMetadata := make(map[string]string)
+			resp.Diagnostics.Append(plan.Metadata.ElementsAs(ctx, &newMetadata, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for k, v := range newMetadata {
+				v := v
+				updateMap[k] = &v
+			}
 		}
-		updateReq.Metadata = metadata
+		if !state.Metadata.IsNull() && !state.Metadata.IsUnknown() {
+			oldMetadata := make(map[string]string)
+			resp.Diagnostics.Append(state.Metadata.ElementsAs(ctx, &oldMetadata, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for key := range oldMetadata {
+				if _, exists := updateMap[key]; !exists {
+					updateMap[key] = nil
+				}
+			}
+		}
+		updateReq.Metadata = updateMap
 	}
 
 	user, err := r.client.UpdateUser(ctx, state.ID.ValueString(), updateReq)


### PR DESCRIPTION
## Summary
- WorkOS API merges metadata on PUT updates instead of replacing it — to delete a key you must send `null`
- The provider used `map[string]string` which can't represent `null`, so removed metadata keys silently persisted on the API side
- This caused `TestAccUserResource_withExternalIDAndMetadata` to fail with "Provider produced inconsistent result after apply"
- Changes `UserUpdateRequest.Metadata` and `OrganizationUpdateRequest.Metadata` to `map[string]*string`
- Update methods now compare old vs new metadata and send `nil` (JSON `null`) for removed keys
- Also handles the edge case where metadata is entirely removed from config (set → null)

Fixes #18

## Test plan
- [ ] `go build ./...` passes
- [ ] `TestAccUserResource_withExternalIDAndMetadata` passes (step 3 — metadata key removal)
- [ ] `TestAccOrganizationResource_WithMetadataAndExternalID` passes
- [ ] All other existing acceptance tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)