### PR TITLE
fix: align Terraform Registry release assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,9 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 
 checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 
@@ -63,6 +66,7 @@ release:
   prerelease: auto
   extra_files:
     - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 
 changelog:
   use: github


### PR DESCRIPTION
## Summary
- include terraform-registry-manifest.json in GoReleaser checksum generation
- upload the manifest as terraform-provider-workos_<version>_manifest.json
- align release artifacts with HashiCorp's current provider publishing template

## Why
The v2.3.0 GitHub release completed, but Terraform Registry stayed on v2.2.1 after a 30-minute poll. Current HashiCorp publishing docs/template require the manifest to be provider/version-named and included in SHA256SUMS. This patch creates a clean patch release instead of mutating v2.3.0 assets.

## Verification
- go run github.com/goreleaser/goreleaser/v2@latest check
- git diff --check
- go test ./...