### PR TITLE
fix: serialize organization role mutations

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -39,6 +39,10 @@ type Client struct {
 	apiKey     string
 	clientID   string
 	baseURL    string
+
+	// Organization role mutations update a priority list shared by every role
+	// in the organization, so concurrent requests must be coordinated.
+	organizationRoleMutations keyedLock
 }
 
 // NewClient creates a new WorkOS API client

--- a/internal/client/keyed_lock.go
+++ b/internal/client/keyed_lock.go
@@ -1,0 +1,77 @@
+// Copyright (c) OSO DevOps
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"sync"
+)
+
+// keyedLock serializes work for the same key while allowing different keys to
+// proceed concurrently. Entries are reference counted so organizations that
+// are no longer being mutated do not remain in memory for the client's
+// lifetime.
+type keyedLock struct {
+	mu      sync.Mutex
+	entries map[string]*keyedLockEntry
+}
+
+type keyedLockEntry struct {
+	semaphore  chan struct{}
+	references int
+}
+
+// lock waits until key is available or ctx is canceled. The returned unlock
+// function must be called exactly once after a successful lock.
+func (l *keyedLock) lock(ctx context.Context, key string) (func(), error) {
+	entry := l.retain(key)
+
+	// Prefer a cancellation that happened before lock was called over acquiring
+	// an immediately available semaphore.
+	select {
+	case <-ctx.Done():
+		l.releaseReference(key, entry)
+		return nil, ctx.Err()
+	default:
+	}
+
+	select {
+	case entry.semaphore <- struct{}{}:
+		return func() {
+			<-entry.semaphore
+			l.releaseReference(key, entry)
+		}, nil
+	case <-ctx.Done():
+		l.releaseReference(key, entry)
+		return nil, ctx.Err()
+	}
+}
+
+func (l *keyedLock) retain(key string) *keyedLockEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.entries == nil {
+		l.entries = make(map[string]*keyedLockEntry)
+	}
+
+	entry, ok := l.entries[key]
+	if !ok {
+		entry = &keyedLockEntry{semaphore: make(chan struct{}, 1)}
+		l.entries[key] = entry
+	}
+	entry.references++
+
+	return entry
+}
+
+func (l *keyedLock) releaseReference(key string, entry *keyedLockEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry.references--
+	if entry.references == 0 {
+		delete(l.entries, key)
+	}
+}

--- a/internal/client/organization_roles.go
+++ b/internal/client/organization_roles.go
@@ -11,8 +11,14 @@ import (
 
 // CreateOrganizationRole creates a new organization role
 func (c *Client) CreateOrganizationRole(ctx context.Context, orgID string, req *OrganizationRoleCreateRequest) (*OrganizationRole, error) {
+	unlock, err := c.organizationRoleMutations.lock(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create organization role: %w", err)
+	}
+	defer unlock()
+
 	var role OrganizationRole
-	err := c.Post(ctx, fmt.Sprintf("/authorization/organizations/%s/roles", url.PathEscape(orgID)), req, &role)
+	err = c.Post(ctx, fmt.Sprintf("/authorization/organizations/%s/roles", url.PathEscape(orgID)), req, &role)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create organization role: %w", err)
 	}
@@ -31,8 +37,14 @@ func (c *Client) GetOrganizationRole(ctx context.Context, orgID, slug string) (*
 
 // UpdateOrganizationRole updates an existing organization role
 func (c *Client) UpdateOrganizationRole(ctx context.Context, orgID, slug string, req *OrganizationRoleUpdateRequest) (*OrganizationRole, error) {
+	unlock, err := c.organizationRoleMutations.lock(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update organization role: %w", err)
+	}
+	defer unlock()
+
 	var role OrganizationRole
-	err := c.Patch(ctx, fmt.Sprintf("/authorization/organizations/%s/roles/%s", url.PathEscape(orgID), url.PathEscape(slug)), req, &role)
+	err = c.Patch(ctx, fmt.Sprintf("/authorization/organizations/%s/roles/%s", url.PathEscape(orgID), url.PathEscape(slug)), req, &role)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update organization role: %w", err)
 	}
@@ -41,7 +53,13 @@ func (c *Client) UpdateOrganizationRole(ctx context.Context, orgID, slug string,
 
 // DeleteOrganizationRole deletes an organization role by slug
 func (c *Client) DeleteOrganizationRole(ctx context.Context, orgID, slug string) error {
-	err := c.Delete(ctx, fmt.Sprintf("/authorization/organizations/%s/roles/%s", url.PathEscape(orgID), url.PathEscape(slug)))
+	unlock, err := c.organizationRoleMutations.lock(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization role: %w", err)
+	}
+	defer unlock()
+
+	err = c.Delete(ctx, fmt.Sprintf("/authorization/organizations/%s/roles/%s", url.PathEscape(orgID), url.PathEscape(slug)))
 	if err != nil {
 		return fmt.Errorf("failed to delete organization role: %w", err)
 	}

--- a/internal/client/organization_roles_test.go
+++ b/internal/client/organization_roles_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) OSO DevOps
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const organizationRoleFixture = `{
+  "id": "role_01JYQ5B9Q6ZP8K4R2T1V0X9ABC",
+  "object": "role",
+  "slug": "org-admin",
+  "name": "Admin",
+  "description": "Can manage all resources",
+  "type": "OrganizationRole",
+  "resource_type_slug": "organization",
+  "permissions": [],
+  "created_at": "2026-01-15T12:00:00.000Z",
+  "updated_at": "2026-01-15T12:00:00.000Z"
+}`
+
+func TestOrganizationRoleMutationsAreSerializedPerOrganization(t *testing.T) {
+	var active atomic.Int32
+	var overlap atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := active.Add(1); got > 1 {
+			overlap.Store(true)
+		}
+		time.Sleep(10 * time.Millisecond)
+		active.Add(-1)
+
+		if r.Method != http.MethodDelete {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(organizationRoleFixture))
+		}
+	}))
+	defer server.Close()
+
+	workosClient, err := NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	const mutationCount = 12
+	start := make(chan struct{})
+	errorsCh := make(chan error, mutationCount)
+	var wg sync.WaitGroup
+	for i := 0; i < mutationCount; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+
+			var mutationErr error
+			switch index % 3 {
+			case 0:
+				_, mutationErr = workosClient.CreateOrganizationRole(context.Background(), "org_shared", &OrganizationRoleCreateRequest{
+					Slug: "org-admin",
+					Name: "Admin",
+				})
+			case 1:
+				_, mutationErr = workosClient.UpdateOrganizationRole(context.Background(), "org_shared", "org-admin", &OrganizationRoleUpdateRequest{
+					Name: "Admin",
+				})
+			case 2:
+				mutationErr = workosClient.DeleteOrganizationRole(context.Background(), "org_shared", "org-admin")
+			}
+			if mutationErr != nil {
+				errorsCh <- mutationErr
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errorsCh)
+
+	for mutationErr := range errorsCh {
+		t.Errorf("organization role mutation failed: %v", mutationErr)
+	}
+	if overlap.Load() {
+		t.Fatal("organization role mutations for the same organization overlapped")
+	}
+
+	workosClient.organizationRoleMutations.mu.Lock()
+	defer workosClient.organizationRoleMutations.mu.Unlock()
+	if got := len(workosClient.organizationRoleMutations.entries); got != 0 {
+		t.Fatalf("expected lock entries to be released, got %d", got)
+	}
+}
+
+func TestOrganizationRoleMutationsForDifferentOrganizationsRemainConcurrent(t *testing.T) {
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+	var releaseFirstOnce sync.Once
+	release := func() { releaseFirstOnce.Do(func() { close(releaseFirst) }) }
+	defer release()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authorization/organizations/org_first/roles":
+			close(firstEntered)
+			<-releaseFirst
+		case "/authorization/organizations/org_second/roles":
+			close(secondEntered)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(organizationRoleFixture))
+	}))
+	defer server.Close()
+
+	workosClient, err := NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	errorsCh := make(chan error, 2)
+	create := func(orgID string) {
+		_, createErr := workosClient.CreateOrganizationRole(context.Background(), orgID, &OrganizationRoleCreateRequest{
+			Slug: "org-admin",
+			Name: "Admin",
+		})
+		errorsCh <- createErr
+	}
+
+	go create("org_first")
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first organization mutation did not reach the server")
+	}
+
+	go create("org_second")
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("second organization mutation was blocked by a different organization")
+	}
+	release()
+
+	for i := 0; i < 2; i++ {
+		if createErr := <-errorsCh; createErr != nil {
+			t.Errorf("CreateOrganizationRole returned error: %v", createErr)
+		}
+	}
+}
+
+func TestOrganizationRoleMutationLockHonorsContextCancellation(t *testing.T) {
+	requestEntered := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var requestCount atomic.Int32
+	var releaseRequestOnce sync.Once
+	release := func() { releaseRequestOnce.Do(func() { close(releaseRequest) }) }
+	defer release()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		close(requestEntered)
+		<-releaseRequest
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(organizationRoleFixture))
+	}))
+	defer server.Close()
+
+	workosClient, err := NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, createErr := workosClient.CreateOrganizationRole(context.Background(), "org_shared", &OrganizationRoleCreateRequest{
+			Slug: "org-admin",
+			Name: "Admin",
+		})
+		firstDone <- createErr
+	}()
+
+	select {
+	case <-requestEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first organization mutation did not reach the server")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	secondDone := make(chan error, 1)
+	go func() {
+		_, createErr := workosClient.CreateOrganizationRole(ctx, "org_shared", &OrganizationRoleCreateRequest{
+			Slug: "org-editor",
+			Name: "Editor",
+		})
+		secondDone <- createErr
+	}()
+
+	// Give the second request time to wait on the held organization lock.
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case createErr := <-secondDone:
+		if !errors.Is(createErr, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", createErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled organization mutation remained blocked")
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("canceled mutation reached the server: got %d requests", got)
+	}
+
+	release()
+	if createErr := <-firstDone; createErr != nil {
+		t.Fatalf("first CreateOrganizationRole returned error: %v", createErr)
+	}
+}

--- a/internal/provider/resource_organization_role_test.go
+++ b/internal/provider/resource_organization_role_test.go
@@ -81,6 +81,29 @@ func TestAccOrganizationRoleResource_NoDescription(t *testing.T) {
 	})
 }
 
+func TestAccOrganizationRoleResource_Concurrent(t *testing.T) {
+	orgName := fmt.Sprintf("tf-acc-test-concurrent-%d", time.Now().UnixNano())
+	slugPrefix := fmt.Sprintf("org-tf-concurrent-%x", time.Now().UnixNano())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationRoleResourceConcurrentConfig(orgName, slugPrefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_organization_role.concurrent[\"admin\"]", "name", "Admin"),
+					resource.TestCheckResourceAttr("workos_organization_role.concurrent[\"editor\"]", "name", "Editor"),
+					resource.TestCheckResourceAttr("workos_organization_role.concurrent[\"viewer\"]", "name", "Viewer"),
+					resource.TestCheckResourceAttrSet("workos_organization_role.concurrent[\"admin\"]", "id"),
+					resource.TestCheckResourceAttrSet("workos_organization_role.concurrent[\"editor\"]", "id"),
+					resource.TestCheckResourceAttrSet("workos_organization_role.concurrent[\"viewer\"]", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccOrganizationRoleResourceConfig(orgName, slug, name, description string) string {
 	return fmt.Sprintf(`
 resource "workos_organization" "test" {
@@ -108,4 +131,33 @@ resource "workos_organization_role" "test" {
   name            = %[3]q
 }
 `, orgName, slug, name)
+}
+
+func testAccOrganizationRoleResourceConcurrentConfig(orgName, slugPrefix string) string {
+	return fmt.Sprintf(`
+resource "workos_organization" "concurrent" {
+  name = %[1]q
+}
+
+resource "workos_organization_role" "concurrent" {
+  for_each = {
+    admin = {
+      slug = "%[2]s-admin"
+      name = "Admin"
+    }
+    editor = {
+      slug = "%[2]s-editor"
+      name = "Editor"
+    }
+    viewer = {
+      slug = "%[2]s-viewer"
+      name = "Viewer"
+    }
+  }
+
+  organization_id = workos_organization.concurrent.id
+  slug            = each.value.slug
+  name            = each.value.name
+}
+`, orgName, slugPrefix)
 }


### PR DESCRIPTION
## Summary

- serialize organization-role create, update, and delete requests per organization to prevent WorkOS priority-list races
- preserve concurrency between different organizations and honor context cancellation while waiting
- add HTTP-level concurrency regression coverage and a Terraform acceptance test matching the reported `for_each` scenario

## Triage

This is a provider bug. Organization role mutations operate on an organization-scoped priority order, while Terraform creates independent role resources concurrently. The provider previously sent those mutations without coordination.

The fix uses organization-scoped serialization instead of retrying create requests. `POST` is not documented as idempotent, so an automatic retry could duplicate or incorrectly adopt a role after partial server-side success.

## Testing

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go generate ./...` (clean diff)
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...`
- focused organization-role race tests passed 10 consecutive runs

A live WorkOS acceptance regression is included but was not run locally because `WORKOS_API_KEY` is not available in this environment.

Closes #28