### PR TITLE
test: support for_each acceptance state checks

### DIFF
--- a/internal/provider/resource_organization_role_test.go
+++ b/internal/provider/resource_organization_role_test.go
@@ -91,17 +91,37 @@ func TestAccOrganizationRoleResource_Concurrent(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationRoleResourceConcurrentConfig(orgName, slugPrefix),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("workos_organization_role.concurrent[\"admin\"]", "name", "Admin"),
-					resource.TestCheckResourceAttr("workos_organization_role.concurrent[\"editor\"]", "name", "Editor"),
-					resource.TestCheckResourceAttr("workos_organization_role.concurrent[\"viewer\"]", "name", "Viewer"),
-					resource.TestCheckResourceAttrSet("workos_organization_role.concurrent[\"admin\"]", "id"),
-					resource.TestCheckResourceAttrSet("workos_organization_role.concurrent[\"editor\"]", "id"),
-					resource.TestCheckResourceAttrSet("workos_organization_role.concurrent[\"viewer\"]", "id"),
-				),
+				Check:  testCheckConcurrentOrganizationRoles,
 			},
 		},
 	})
+}
+
+func testCheckConcurrentOrganizationRoles(state *terraform.State) error {
+	expectedRoles := []struct {
+		key  string
+		name string
+	}{
+		{key: "admin", name: "Admin"},
+		{key: "editor", name: "Editor"},
+		{key: "viewer", name: "Viewer"},
+	}
+
+	for _, expected := range expectedRoles {
+		address := fmt.Sprintf(`workos_organization_role.concurrent[%q]`, expected.key)
+		role, ok := state.RootModule().Resources[address]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", address)
+		}
+		if got := role.Primary.Attributes["name"]; got != expected.name {
+			return fmt.Errorf("expected %s name to be %q, got %q", address, expected.name, got)
+		}
+		if role.Primary.Attributes["id"] == "" {
+			return fmt.Errorf("expected %s id to be set", address)
+		}
+	}
+
+	return nil
 }
 
 func testAccOrganizationRoleResourceConfig(orgName, slug, name, description string) string {


### PR DESCRIPTION
## Summary

- replace terraform-plugin-testing generic checks that cannot parse string-keyed `for_each` addresses
- inspect the resulting Terraform state directly so the concurrent role acceptance scenario remains fully asserted

## Context

The live WorkOS apply succeeded for all concurrent roles after #29. The acceptance job failed only when the v1.6 test helper attempted to resolve addresses such as `workos_organization_role.concurrent["admin"]`.

## Testing

- `go test -race ./internal/provider -run TestAccOrganizationRoleResource_Concurrent -count=1`
- `go vet ./internal/provider`

Follow-up to #29.