### PR TITLE
fix: handle unknown values in connect application plans

### DIFF
--- a/internal/provider/resource_connect_application.go
+++ b/internal/provider/resource_connect_application.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -29,25 +30,40 @@ type ConnectApplicationResource struct {
 	client *client.Client
 }
 
+// ConnectApplicationResourceModel mirrors the resource schema. Every attribute
+// uses a `types` value because Terraform sends unknown values for computed and
+// optional+computed attributes during Create, and only the framework types can
+// represent an unknown.
 type ConnectApplicationResourceModel struct {
-	ID                       types.String                         `tfsdk:"id"`
-	ClientID                 types.String                         `tfsdk:"client_id"`
-	Name                     types.String                         `tfsdk:"name"`
-	Description              types.String                         `tfsdk:"description"`
-	ApplicationType          types.String                         `tfsdk:"application_type"`
-	OrganizationID           types.String                         `tfsdk:"organization_id"`
-	IsFirstParty             types.Bool                           `tfsdk:"is_first_party"`
-	UsesPKCE                 types.Bool                           `tfsdk:"uses_pkce"`
-	WasDynamicallyRegistered types.Bool                           `tfsdk:"was_dynamically_registered"`
-	Scopes                   types.List                           `tfsdk:"scopes"`
-	RedirectURIs             []ConnectApplicationRedirectURIModel `tfsdk:"redirect_uris"`
-	CreatedAt                types.String                         `tfsdk:"created_at"`
-	UpdatedAt                types.String                         `tfsdk:"updated_at"`
+	ID                       types.String `tfsdk:"id"`
+	ClientID                 types.String `tfsdk:"client_id"`
+	Name                     types.String `tfsdk:"name"`
+	Description              types.String `tfsdk:"description"`
+	ApplicationType          types.String `tfsdk:"application_type"`
+	OrganizationID           types.String `tfsdk:"organization_id"`
+	IsFirstParty             types.Bool   `tfsdk:"is_first_party"`
+	UsesPKCE                 types.Bool   `tfsdk:"uses_pkce"`
+	WasDynamicallyRegistered types.Bool   `tfsdk:"was_dynamically_registered"`
+	Scopes                   types.List   `tfsdk:"scopes"`
+	RedirectURIs             types.List   `tfsdk:"redirect_uris"`
+	CreatedAt                types.String `tfsdk:"created_at"`
+	UpdatedAt                types.String `tfsdk:"updated_at"`
 }
 
 type ConnectApplicationRedirectURIModel struct {
 	URI     types.String `tfsdk:"uri"`
 	Default types.Bool   `tfsdk:"default"`
+}
+
+// connectApplicationRedirectURIAttrTypes describes a single redirect_uris
+// element and must stay in sync with the nested object in the schema.
+var connectApplicationRedirectURIAttrTypes = map[string]attr.Type{
+	"uri":     types.StringType,
+	"default": types.BoolType,
+}
+
+func connectApplicationRedirectURIObjectType() types.ObjectType {
+	return types.ObjectType{AttrTypes: connectApplicationRedirectURIAttrTypes}
 }
 
 func (r *ConnectApplicationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -181,7 +197,14 @@ func (r *ConnectApplicationResource) Create(ctx context.Context, req resource.Cr
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !validateConnectApplicationPlan(&plan, &resp.Diagnostics) {
+
+	redirectURIs, diags := redirectURIsFromTerraform(ctx, plan.RedirectURIs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !validateConnectApplicationPlan(&plan, redirectURIs, &resp.Diagnostics) {
 		return
 	}
 
@@ -195,7 +218,7 @@ func (r *ConnectApplicationResource) Create(ctx context.Context, req resource.Cr
 		ApplicationType: plan.ApplicationType.ValueString(),
 		Name:            plan.Name.ValueString(),
 		Scopes:          scopes,
-		RedirectURIs:    redirectURIInputs(plan.RedirectURIs),
+		RedirectURIs:    redirectURIInputs(redirectURIs),
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		createReq.Description = plan.Description.ValueString()
@@ -260,7 +283,14 @@ func (r *ConnectApplicationResource) Update(ctx context.Context, req resource.Up
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if !validateConnectApplicationPlan(&plan, &resp.Diagnostics) {
+
+	redirectURIs, diags := redirectURIsFromTerraform(ctx, plan.RedirectURIs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !validateConnectApplicationPlan(&plan, redirectURIs, &resp.Diagnostics) {
 		return
 	}
 
@@ -273,7 +303,7 @@ func (r *ConnectApplicationResource) Update(ctx context.Context, req resource.Up
 	updateReq := &client.ConnectApplicationUpdateRequest{
 		Name:         plan.Name.ValueString(),
 		Scopes:       scopes,
-		RedirectURIs: redirectURIInputs(plan.RedirectURIs),
+		RedirectURIs: redirectURIInputs(redirectURIs),
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		updateReq.Description = plan.Description.ValueString()
@@ -313,7 +343,7 @@ func (r *ConnectApplicationResource) ImportState(ctx context.Context, req resour
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func validateConnectApplicationPlan(plan *ConnectApplicationResourceModel, diags *diag.Diagnostics) bool {
+func validateConnectApplicationPlan(plan *ConnectApplicationResourceModel, redirectURIs []ConnectApplicationRedirectURIModel, diags *diag.Diagnostics) bool {
 	applicationType := plan.ApplicationType.ValueString()
 	if applicationType != "oauth" && applicationType != "m2m" {
 		diags.AddAttributeError(path.Root("application_type"), "Invalid Application Type", "application_type must be either 'oauth' or 'm2m'.")
@@ -325,7 +355,7 @@ func validateConnectApplicationPlan(plan *ConnectApplicationResourceModel, diags
 		return false
 	}
 
-	if applicationType == "m2m" && len(plan.RedirectURIs) > 0 {
+	if applicationType == "m2m" && len(redirectURIs) > 0 {
 		diags.AddAttributeError(path.Root("redirect_uris"), "Unsupported Redirect URIs", "redirect_uris can only be configured for oauth Connect applications.")
 		return false
 	}
@@ -352,6 +382,21 @@ func stringListFromTerraform(ctx context.Context, value types.List) ([]string, d
 	return values, diags
 }
 
+// redirectURIsFromTerraform converts the redirect_uris list into Go models.
+// A null or unknown list means "not configured" — redirect_uris is
+// optional+computed, so Terraform sends it as unknown during Create whenever the
+// practitioner leaves it out.
+func redirectURIsFromTerraform(ctx context.Context, value types.List) ([]ConnectApplicationRedirectURIModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if value.IsNull() || value.IsUnknown() {
+		return nil, diags
+	}
+
+	var values []ConnectApplicationRedirectURIModel
+	diags.Append(value.ElementsAs(ctx, &values, false)...)
+	return values, diags
+}
+
 func redirectURIInputs(values []ConnectApplicationRedirectURIModel) []client.ConnectApplicationRedirectURIInput {
 	if len(values) == 0 {
 		return nil
@@ -371,31 +416,42 @@ func redirectURIInputs(values []ConnectApplicationRedirectURIModel) []client.Con
 	return inputs
 }
 
+// connectApplicationToState writes an API response over the plan (Create and
+// Update) or the prior state (Read). Every attribute must end up known:
+// leaving an unknown behind makes Terraform fail the apply.
 func connectApplicationToState(ctx context.Context, state *ConnectApplicationResourceModel, app *client.ConnectApplication, diags *diag.Diagnostics) {
 	state.ID = types.StringValue(app.ID)
 	state.ClientID = types.StringValue(app.ClientID)
 	state.Name = types.StringValue(app.Name)
-	state.Description = optionalString(app.Description)
-	state.ApplicationType = optionalString(app.ApplicationType)
-	state.OrganizationID = optionalString(app.OrganizationID)
-	state.IsFirstParty = optionalBool(app.IsFirstParty)
-	state.UsesPKCE = optionalBool(app.UsesPKCE)
+	state.Description = optionalStringOrCurrent(app.Description, state.Description)
+	state.ApplicationType = optionalStringOrCurrent(app.ApplicationType, state.ApplicationType)
+	state.OrganizationID = optionalStringOrCurrent(app.OrganizationID, state.OrganizationID)
+	state.IsFirstParty = optionalBoolOrCurrent(app.IsFirstParty, state.IsFirstParty)
+	state.UsesPKCE = optionalBoolOrCurrent(app.UsesPKCE, state.UsesPKCE)
 	state.WasDynamicallyRegistered = optionalBool(app.WasDynamicallyRegistered)
 
-	if len(app.Scopes) > 0 {
-		scopes, scopeDiags := types.ListValueFrom(ctx, types.StringType, app.Scopes)
-		diags.Append(scopeDiags...)
+	scopes, scopeDiags := types.ListValueFrom(ctx, types.StringType, app.Scopes)
+	diags.Append(scopeDiags...)
+	if !scopeDiags.HasError() {
+		if app.Scopes == nil {
+			// A null list would leave a configured-but-empty attribute
+			// inconsistent with the plan; use an empty list instead.
+			scopes = types.ListValueMust(types.StringType, []attr.Value{})
+		}
 		state.Scopes = scopes
-	} else {
-		state.Scopes, _ = types.ListValueFrom(ctx, types.StringType, []string{})
 	}
 
-	state.RedirectURIs = make([]ConnectApplicationRedirectURIModel, 0, len(app.RedirectURIs))
+	redirectURIs := make([]ConnectApplicationRedirectURIModel, 0, len(app.RedirectURIs))
 	for _, redirectURI := range app.RedirectURIs {
-		state.RedirectURIs = append(state.RedirectURIs, ConnectApplicationRedirectURIModel{
+		redirectURIs = append(redirectURIs, ConnectApplicationRedirectURIModel{
 			URI:     types.StringValue(redirectURI.URI),
 			Default: types.BoolValue(redirectURI.Default),
 		})
+	}
+	redirectURIList, redirectDiags := types.ListValueFrom(ctx, connectApplicationRedirectURIObjectType(), redirectURIs)
+	diags.Append(redirectDiags...)
+	if !redirectDiags.HasError() {
+		state.RedirectURIs = redirectURIList
 	}
 
 	state.CreatedAt = types.StringValue(app.CreatedAt.Format(time.RFC3339))
@@ -407,4 +463,29 @@ func optionalBool(value *bool) types.Bool {
 		return types.BoolNull()
 	}
 	return types.BoolValue(*value)
+}
+
+// optionalStringOrCurrent keeps the planned (or prior) value when the API omits
+// an optional attribute from its response. Overwriting a configured value with
+// null makes Terraform reject the apply with "Provider produced inconsistent
+// result after apply"; an unknown has no value worth keeping, so it becomes null.
+func optionalStringOrCurrent(value *string, current types.String) types.String {
+	if value != nil {
+		return types.StringValue(*value)
+	}
+	if current.IsUnknown() {
+		return types.StringNull()
+	}
+	return current
+}
+
+// optionalBoolOrCurrent is optionalStringOrCurrent for booleans.
+func optionalBoolOrCurrent(value *bool, current types.Bool) types.Bool {
+	if value != nil {
+		return types.BoolValue(*value)
+	}
+	if current.IsUnknown() {
+		return types.BoolNull()
+	}
+	return current
 }

--- a/internal/provider/resource_connect_application_test.go
+++ b/internal/provider/resource_connect_application_test.go
@@ -1,0 +1,604 @@
+// Copyright (c) OSO DevOps
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/osodevops/terraform-provider-workos/internal/client"
+)
+
+// connectApplicationMockAPI is a minimal in-memory stand-in for the WorkOS API
+// covering the endpoints the Connect application resource (and the organization
+// resource it commonly depends on) exercises. It lets the provider be driven
+// end to end without a live WorkOS environment.
+type connectApplicationMockAPI struct {
+	mu            sync.Mutex
+	counter       int
+	applications  map[string]*client.ConnectApplication
+	organizations map[string]*client.Organization
+
+	// omitOptionalFields makes the mock leave optional attributes out of its
+	// responses, as the WorkOS API does for fields that do not apply to a given
+	// application type. The provider must keep the configured values rather than
+	// nulling them out.
+	omitOptionalFields bool
+}
+
+func newConnectApplicationMockAPI(t *testing.T) (*connectApplicationMockAPI, *httptest.Server) {
+	t.Helper()
+
+	api := &connectApplicationMockAPI{
+		applications:  make(map[string]*client.ConnectApplication),
+		organizations: make(map[string]*client.Organization),
+	}
+	server := httptest.NewServer(api)
+	t.Cleanup(server.Close)
+
+	return api, server
+}
+
+func (a *connectApplicationMockAPI) nextID(prefix string) string {
+	a.counter++
+	return fmt.Sprintf("%s_%08d", prefix, a.counter)
+}
+
+func (a *connectApplicationMockAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	switch {
+	case r.URL.Path == "/organizations" && r.Method == http.MethodPost:
+		a.createOrganization(w, r)
+	case strings.HasPrefix(r.URL.Path, "/organizations/"):
+		a.organizationByID(w, r, strings.TrimPrefix(r.URL.Path, "/organizations/"))
+	case r.URL.Path == "/connect/applications" && r.Method == http.MethodPost:
+		a.createApplication(w, r)
+	case strings.HasPrefix(r.URL.Path, "/connect/applications/"):
+		a.applicationByID(w, r, strings.TrimPrefix(r.URL.Path, "/connect/applications/"))
+	default:
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+	}
+}
+
+func (a *connectApplicationMockAPI) createOrganization(w http.ResponseWriter, r *http.Request) {
+	var req client.OrganizationCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	org := &client.Organization{
+		ID:        a.nextID("org"),
+		Object:    "organization",
+		Name:      req.Name,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	a.organizations[org.ID] = org
+	writeJSON(w, http.StatusCreated, org)
+}
+
+func (a *connectApplicationMockAPI) organizationByID(w http.ResponseWriter, r *http.Request, id string) {
+	org, ok := a.organizations[id]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, org)
+	case http.MethodDelete:
+		delete(a.organizations, id)
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *connectApplicationMockAPI) createApplication(w http.ResponseWriter, r *http.Request) {
+	var req client.ConnectApplicationCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &client.ConnectApplication{
+		ID:              a.nextID("app"),
+		Object:          "connect_application",
+		ClientID:        a.nextID("client"),
+		Name:            req.Name,
+		ApplicationType: stringPtrOrNil(req.ApplicationType),
+		OrganizationID:  stringPtrOrNil(req.OrganizationID),
+		Scopes:          req.Scopes,
+		UsesPKCE:        req.UsesPKCE,
+		IsFirstParty:    req.IsFirstParty,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if req.Description != "" {
+		description := req.Description
+		app.Description = &description
+	}
+	app.RedirectURIs = redirectURIsFromInputs(req.RedirectURIs)
+
+	if a.omitOptionalFields {
+		app.ApplicationType = nil
+		app.OrganizationID = nil
+		app.Description = nil
+		app.IsFirstParty = nil
+		app.UsesPKCE = nil
+	}
+
+	a.applications[app.ID] = app
+	writeJSON(w, http.StatusCreated, app)
+}
+
+func (a *connectApplicationMockAPI) applicationByID(w http.ResponseWriter, r *http.Request, id string) {
+	app, ok := a.applications[id]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, app)
+	case http.MethodPut:
+		var req client.ConnectApplicationUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Name != "" {
+			app.Name = req.Name
+		}
+		if req.Description != "" {
+			description := req.Description
+			app.Description = &description
+		}
+		app.Scopes = req.Scopes
+		app.RedirectURIs = redirectURIsFromInputs(req.RedirectURIs)
+		app.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+		writeJSON(w, http.StatusOK, app)
+	case http.MethodDelete:
+		delete(a.applications, id)
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func redirectURIsFromInputs(inputs []client.ConnectApplicationRedirectURIInput) []client.ConnectApplicationRedirectURI {
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	uris := make([]client.ConnectApplicationRedirectURI, 0, len(inputs))
+	for _, input := range inputs {
+		uri := client.ConnectApplicationRedirectURI{URI: input.URI}
+		if input.Default != nil {
+			uri.Default = *input.Default
+		}
+		uris = append(uris, uri)
+	}
+	return uris
+}
+
+func stringPtrOrNil(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// connectApplicationSchema returns the resource schema under test.
+func connectApplicationSchema(t *testing.T) schema.Schema {
+	t.Helper()
+
+	resp := &fwresource.SchemaResponse{}
+	(&ConnectApplicationResource{}).Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %v", resp.Diagnostics)
+	}
+	return resp.Schema
+}
+
+// connectApplicationPlan builds the plan Terraform hands to Create: every
+// attribute the practitioner did not configure is unknown, exactly as it is for
+// an Optional+Computed attribute with no prior state.
+func connectApplicationPlan(t *testing.T, s schema.Schema, known map[string]tftypes.Value) tfsdk.Plan {
+	t.Helper()
+
+	objectType, ok := s.Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected object type for schema, got %T", s.Type().TerraformType(context.Background()))
+	}
+
+	values := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+	for name, attributeType := range objectType.AttributeTypes {
+		if value, found := known[name]; found {
+			values[name] = value
+			continue
+		}
+		values[name] = tftypes.NewValue(attributeType, tftypes.UnknownValue)
+	}
+
+	return tfsdk.Plan{
+		Schema: s,
+		Raw:    tftypes.NewValue(objectType, values),
+	}
+}
+
+func connectApplicationNullState(t *testing.T, s schema.Schema) tfsdk.State {
+	t.Helper()
+
+	return tfsdk.State{
+		Schema: s,
+		Raw:    tftypes.NewValue(s.Type().TerraformType(context.Background()), nil),
+	}
+}
+
+// TestConnectApplicationResourceCreate_M2MUnknownComputedAttributes reproduces
+// https://github.com/osodevops/terraform-provider-workos/issues/34: creating an
+// m2m Connect application without redirect_uris/scopes failed with a
+// "Value Conversion Error" before any API request was made, because the plan
+// carries unknown values for every unconfigured Optional+Computed attribute.
+func TestConnectApplicationResourceCreate_M2MUnknownComputedAttributes(t *testing.T) {
+	ctx := context.Background()
+	api, server := newConnectApplicationMockAPI(t)
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &ConnectApplicationResource{client: workosClient}
+
+	s := connectApplicationSchema(t)
+	plan := connectApplicationPlan(t, s, map[string]tftypes.Value{
+		"name":             tftypes.NewValue(tftypes.String, "example-widget"),
+		"application_type": tftypes.NewValue(tftypes.String, "m2m"),
+		"organization_id":  tftypes.NewValue(tftypes.String, "org_00000001"),
+	})
+
+	resp := &fwresource.CreateResponse{State: connectApplicationNullState(t, s)}
+	r.Create(ctx, fwresource.CreateRequest{Plan: plan}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned errors: %v", resp.Diagnostics)
+	}
+
+	if len(api.applications) != 1 {
+		t.Fatalf("expected 1 application to be created, got %d", len(api.applications))
+	}
+
+	var state ConnectApplicationResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+
+	if state.ID.IsNull() || state.ID.IsUnknown() {
+		t.Fatalf("expected id to be set in state, got %v", state.ID)
+	}
+	if state.ClientID.IsNull() || state.ClientID.IsUnknown() {
+		t.Fatalf("expected client_id to be set in state, got %v", state.ClientID)
+	}
+	if state.OrganizationID.ValueString() != "org_00000001" {
+		t.Fatalf("expected organization_id org_00000001, got %q", state.OrganizationID.ValueString())
+	}
+	if state.RedirectURIs.IsUnknown() {
+		t.Fatal("expected redirect_uris to be known after create")
+	}
+	if state.Scopes.IsUnknown() {
+		t.Fatal("expected scopes to be known after create")
+	}
+}
+
+// TestConnectApplicationResourceCreate_OAuthWithRedirectURIs covers the
+// configured-list path so the unknown-value fix does not regress the case where
+// redirect_uris and scopes are supplied.
+func TestConnectApplicationResourceCreate_OAuthWithRedirectURIs(t *testing.T) {
+	ctx := context.Background()
+	api, server := newConnectApplicationMockAPI(t)
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &ConnectApplicationResource{client: workosClient}
+
+	s := connectApplicationSchema(t)
+	redirectURIType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"uri":     tftypes.String,
+		"default": tftypes.Bool,
+	}}
+	plan := connectApplicationPlan(t, s, map[string]tftypes.Value{
+		"name":             tftypes.NewValue(tftypes.String, "example-oauth"),
+		"application_type": tftypes.NewValue(tftypes.String, "oauth"),
+		"scopes": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+			tftypes.NewValue(tftypes.String, "openid"),
+			tftypes.NewValue(tftypes.String, "profile"),
+		}),
+		"redirect_uris": tftypes.NewValue(tftypes.List{ElementType: redirectURIType}, []tftypes.Value{
+			tftypes.NewValue(redirectURIType, map[string]tftypes.Value{
+				"uri":     tftypes.NewValue(tftypes.String, "https://example.com/callback"),
+				"default": tftypes.NewValue(tftypes.Bool, true),
+			}),
+		}),
+	})
+
+	resp := &fwresource.CreateResponse{State: connectApplicationNullState(t, s)}
+	r.Create(ctx, fwresource.CreateRequest{Plan: plan}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned errors: %v", resp.Diagnostics)
+	}
+
+	var created *client.ConnectApplication
+	for _, app := range api.applications {
+		created = app
+	}
+	if created == nil {
+		t.Fatal("expected an application to be created")
+	}
+	if len(created.RedirectURIs) != 1 || created.RedirectURIs[0].URI != "https://example.com/callback" || !created.RedirectURIs[0].Default {
+		t.Fatalf("unexpected redirect URIs sent to API: %#v", created.RedirectURIs)
+	}
+	if len(created.Scopes) != 2 {
+		t.Fatalf("unexpected scopes sent to API: %#v", created.Scopes)
+	}
+
+	var state ConnectApplicationResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+	if got := len(state.RedirectURIs.Elements()); got != 1 {
+		t.Fatalf("expected 1 redirect URI in state, got %d", got)
+	}
+}
+
+// TestConnectApplicationResourceCreate_M2MRejectsRedirectURIs keeps the
+// validation behaviour for m2m applications intact.
+func TestConnectApplicationResourceCreate_M2MRejectsRedirectURIs(t *testing.T) {
+	ctx := context.Background()
+	_, server := newConnectApplicationMockAPI(t)
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &ConnectApplicationResource{client: workosClient}
+
+	s := connectApplicationSchema(t)
+	redirectURIType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"uri":     tftypes.String,
+		"default": tftypes.Bool,
+	}}
+	plan := connectApplicationPlan(t, s, map[string]tftypes.Value{
+		"name":             tftypes.NewValue(tftypes.String, "example-widget"),
+		"application_type": tftypes.NewValue(tftypes.String, "m2m"),
+		"organization_id":  tftypes.NewValue(tftypes.String, "org_00000001"),
+		"redirect_uris": tftypes.NewValue(tftypes.List{ElementType: redirectURIType}, []tftypes.Value{
+			tftypes.NewValue(redirectURIType, map[string]tftypes.Value{
+				"uri":     tftypes.NewValue(tftypes.String, "https://example.com/callback"),
+				"default": tftypes.NewValue(tftypes.Bool, true),
+			}),
+		}),
+	})
+
+	resp := &fwresource.CreateResponse{State: connectApplicationNullState(t, s)}
+	r.Create(ctx, fwresource.CreateRequest{Plan: plan}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected an error when redirect_uris are set on an m2m application")
+	}
+}
+
+// TestConnectApplicationResourceCreate_SparseAPIResponse asserts that
+// attributes the practitioner configured survive an API response that omits
+// them. Nulling them out would make Terraform reject the apply with
+// "Provider produced inconsistent result after apply".
+func TestConnectApplicationResourceCreate_SparseAPIResponse(t *testing.T) {
+	ctx := context.Background()
+	api, server := newConnectApplicationMockAPI(t)
+	api.omitOptionalFields = true
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &ConnectApplicationResource{client: workosClient}
+
+	s := connectApplicationSchema(t)
+	plan := connectApplicationPlan(t, s, map[string]tftypes.Value{
+		"name":             tftypes.NewValue(tftypes.String, "example-widget"),
+		"application_type": tftypes.NewValue(tftypes.String, "m2m"),
+		"organization_id":  tftypes.NewValue(tftypes.String, "org_00000001"),
+		"description":      tftypes.NewValue(tftypes.String, "a widget"),
+	})
+
+	resp := &fwresource.CreateResponse{State: connectApplicationNullState(t, s)}
+	r.Create(ctx, fwresource.CreateRequest{Plan: plan}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned errors: %v", resp.Diagnostics)
+	}
+
+	var state ConnectApplicationResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+
+	if state.ApplicationType.ValueString() != "m2m" {
+		t.Fatalf("expected application_type to be preserved as m2m, got %v", state.ApplicationType)
+	}
+	if state.OrganizationID.ValueString() != "org_00000001" {
+		t.Fatalf("expected organization_id to be preserved, got %v", state.OrganizationID)
+	}
+	if state.Description.ValueString() != "a widget" {
+		t.Fatalf("expected description to be preserved, got %v", state.Description)
+	}
+	// Unconfigured optional attributes have no value worth keeping, so an
+	// unknown must collapse to null rather than stay unknown.
+	if state.UsesPKCE.IsUnknown() || !state.UsesPKCE.IsNull() {
+		t.Fatalf("expected uses_pkce to be null, got %v", state.UsesPKCE)
+	}
+}
+
+// TestAccConnectApplicationResource_M2MSparseAPIResponse runs the same scenario
+// through Terraform, which independently enforces that the applied state
+// matches the plan.
+func TestAccConnectApplicationResource_M2MSparseAPIResponse(t *testing.T) {
+	api, server := newConnectApplicationMockAPI(t)
+	api.omitOptionalFields = true
+
+	t.Setenv("WORKOS_API_KEY", "sk_test")
+	t.Setenv("WORKOS_BASE_URL", server.URL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectApplicationMockConfig(server.URL, "example-widget"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_connect_application.m2m", "application_type", "m2m"),
+					resource.TestCheckResourceAttrPair(
+						"workos_connect_application.m2m", "organization_id",
+						"workos_organization.public", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccConnectApplicationResource_M2MMockAPI drives the full Terraform
+// lifecycle for the configuration reported in issue #34 against the mock WorkOS
+// API, so it runs without live credentials. Requires the Terraform CLI.
+func TestAccConnectApplicationResource_M2MMockAPI(t *testing.T) {
+	_, server := newConnectApplicationMockAPI(t)
+
+	t.Setenv("WORKOS_API_KEY", "sk_test")
+	t.Setenv("WORKOS_BASE_URL", server.URL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectApplicationMockConfig(server.URL, "example-widget"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_connect_application.m2m", "name", "example-widget"),
+					resource.TestCheckResourceAttr("workos_connect_application.m2m", "application_type", "m2m"),
+					resource.TestCheckResourceAttrSet("workos_connect_application.m2m", "id"),
+					resource.TestCheckResourceAttrSet("workos_connect_application.m2m", "client_id"),
+					resource.TestCheckResourceAttrPair(
+						"workos_connect_application.m2m", "organization_id",
+						"workos_organization.public", "id",
+					),
+					resource.TestCheckResourceAttr("workos_connect_application.m2m", "redirect_uris.#", "0"),
+					resource.TestCheckResourceAttr("workos_connect_application.m2m", "scopes.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "workos_connect_application.m2m",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConnectApplicationMockConfig(server.URL, "example-widget-renamed"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_connect_application.m2m", "name", "example-widget-renamed"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccConnectApplicationResource_OAuthMockAPI covers an OAuth application
+// with redirect URIs end to end against the mock WorkOS API.
+func TestAccConnectApplicationResource_OAuthMockAPI(t *testing.T) {
+	_, server := newConnectApplicationMockAPI(t)
+
+	t.Setenv("WORKOS_API_KEY", "sk_test")
+	t.Setenv("WORKOS_BASE_URL", server.URL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectApplicationOAuthMockConfig(server.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_connect_application.oauth", "application_type", "oauth"),
+					resource.TestCheckResourceAttr("workos_connect_application.oauth", "redirect_uris.#", "1"),
+					resource.TestCheckResourceAttr("workos_connect_application.oauth", "redirect_uris.0.uri", "https://example.com/callback"),
+					resource.TestCheckResourceAttr("workos_connect_application.oauth", "redirect_uris.0.default", "true"),
+					resource.TestCheckResourceAttr("workos_connect_application.oauth", "scopes.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConnectApplicationMockConfig(baseURL, name string) string {
+	return fmt.Sprintf(`
+provider "workos" {
+  api_key  = "sk_test"
+  base_url = %[1]q
+}
+
+resource "workos_organization" "public" {
+  name = "Example Public"
+}
+
+resource "workos_connect_application" "m2m" {
+  name             = %[2]q
+  application_type = "m2m"
+  organization_id  = workos_organization.public.id
+}
+`, baseURL, name)
+}
+
+func testAccConnectApplicationOAuthMockConfig(baseURL string) string {
+	return fmt.Sprintf(`
+provider "workos" {
+  api_key  = "sk_test"
+  base_url = %[1]q
+}
+
+resource "workos_connect_application" "oauth" {
+  name             = "example-oauth"
+  application_type = "oauth"
+  scopes           = ["openid", "profile"]
+
+  redirect_uris = [
+    {
+      uri     = "https://example.com/callback"
+      default = true
+    },
+  ]
+}
+`, baseURL)
+}


### PR DESCRIPTION
Fixes #34

## Root cause

`workos_connect_application` modelled `redirect_uris` as a plain Go slice:

```go
RedirectURIs []ConnectApplicationRedirectURIModel `tfsdk:"redirect_uris"`
```

`redirect_uris` is `Optional + Computed`, so Terraform sends it as **unknown** during `Create` whenever the practitioner does not configure it. A plain slice cannot represent an unknown, so `req.Plan.Get(ctx, &plan)` failed before any API call:

```
Received unknown value, however the target type cannot handle unknown values.
Path: redirect_uris
Target Type: []provider.ConnectApplicationRedirectURIModel
Suggested Type: basetypes.ListValue
```

This made **every** m2m create fail, since m2m applications reject redirect URIs outright, and any oauth create that omitted `redirect_uris`. It matches the report exactly: the failure is plan-conversion side, before `POST /connect/applications`.

## Fix

- Model `redirect_uris` as `types.List` and convert to Go models only after null/unknown are handled (`redirectURIsFromTerraform`). Validation and the API request body now take the converted slice.
- Build the state list with `types.ListValueFrom` against an explicit object type, so an application with no redirect URIs lands as a known empty list rather than an unknown.

While verifying the create path end to end, a second failure in the same class showed up: `connectApplicationToState` overwrote every optional attribute with the API response, so a response that omits a field (WorkOS leaves out fields that don't apply to an application type) nulled out the practitioner's configured value and Terraform rejected the apply with `Provider produced inconsistent result after apply`. `optionalStringOrCurrent` / `optionalBoolOrCurrent` now keep the planned or prior value when the API omits a field, and collapse unknown to null.

## Tests

New tests run the resource against an in-memory WorkOS API, so they need no live credentials:

- **Unit** (`go test`, no Terraform CLI) — drives `Create` with the exact plan Terraform produces, every unconfigured optional+computed attribute unknown. Covers the reported m2m config, an oauth app with redirect URIs and scopes, the m2m-rejects-redirect-URIs validation, and the sparse-API-response case.
- **Mock-API acceptance** (`TF_ACC=1`, real Terraform CLI + real provider server) — full create → refresh → import → update lifecycle for the issue's config, including Terraform's own post-apply consistency and empty-plan checks.

Both regression tests were confirmed to fail without the corresponding fix.

Before:

```
--- FAIL: TestAccConnectApplicationResource_M2MMockAPI
    Error: Value Conversion Error
    Path: redirect_uris
    Target Type: []provider.ConnectApplicationRedirectURIModel
```

After:

```
--- PASS: TestConnectApplicationResourceCreate_M2MUnknownComputedAttributes
--- PASS: TestConnectApplicationResourceCreate_OAuthWithRedirectURIs
--- PASS: TestConnectApplicationResourceCreate_M2MRejectsRedirectURIs
--- PASS: TestConnectApplicationResourceCreate_SparseAPIResponse
--- PASS: TestAccConnectApplicationResource_M2MSparseAPIResponse
--- PASS: TestAccConnectApplicationResource_M2MMockAPI
--- PASS: TestAccConnectApplicationResource_OAuthMockAPI
```

`go build ./...`, `go vet ./...`, `go test ./...` and `go generate ./...` (no doc drift) are clean. No schema change, so no provider docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)