### PR TITLE
fix: preserve role permissions when updating name or description

### DIFF
--- a/internal/provider/resource_environment_role.go
+++ b/internal/provider/resource_environment_role.go
@@ -396,6 +396,15 @@ func (r *EnvironmentRoleResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
+	// The role update endpoint does not echo permissions back. When this apply
+	// did not set them, permissions is Computed and planned from prior state, so
+	// taking the update response's empty set would empty it and Terraform would
+	// reject the apply with ".permissions: element N has vanished". Carry the
+	// prior set forward; an out-of-band change is picked up by the next refresh.
+	if !permissionsChanged && !state.Permissions.IsNull() && !state.Permissions.IsUnknown() {
+		plan.Permissions = state.Permissions
+	}
+
 	tflog.Info(ctx, "Updated environment role", map[string]any{
 		"id":   role.ID,
 		"slug": role.Slug,

--- a/internal/provider/resource_environment_role_update_test.go
+++ b/internal/provider/resource_environment_role_update_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) OSO DevOps
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/osodevops/terraform-provider-workos/internal/client"
+)
+
+// environmentRoleMockAPI stands in for the WorkOS environment role endpoints.
+// Like the organization role endpoints, its update response omits the role's
+// permissions.
+type environmentRoleMockAPI struct {
+	mu    sync.Mutex
+	roles map[string]*client.EnvironmentRole
+}
+
+func newEnvironmentRoleMockAPI(t *testing.T) (*environmentRoleMockAPI, *httptest.Server) {
+	t.Helper()
+
+	api := &environmentRoleMockAPI{roles: make(map[string]*client.EnvironmentRole)}
+	server := httptest.NewServer(api)
+	t.Cleanup(server.Close)
+
+	return api, server
+}
+
+func (a *environmentRoleMockAPI) seedRole(role *client.EnvironmentRole) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.roles[role.Slug] = role
+}
+
+func (a *environmentRoleMockAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	rest := strings.TrimPrefix(r.URL.Path, "/authorization/roles/")
+	if rest == r.URL.Path {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	parts := strings.Split(rest, "/")
+	role, ok := a.roles[parts[0]]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	switch {
+	case len(parts) == 1 && r.Method == http.MethodGet:
+		writeJSON(w, http.StatusOK, role)
+	case len(parts) == 1 && r.Method == http.MethodPatch:
+		var req client.EnvironmentRoleUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Name != "" {
+			role.Name = req.Name
+		}
+		role.Description = req.Description
+		role.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+		// The update response omits the role's permissions.
+		response := *role
+		response.Permissions = nil
+		writeJSON(w, http.StatusOK, response)
+	case len(parts) == 2 && parts[1] == "permissions" && r.Method == http.MethodPut:
+		var req client.EnvironmentRolePermissionsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		role.Permissions = req.Permissions
+		role.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+		writeJSON(w, http.StatusOK, role)
+	default:
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+	}
+}
+
+func environmentRoleSchema(t *testing.T) schema.Schema {
+	t.Helper()
+
+	resp := &fwresource.SchemaResponse{}
+	(&EnvironmentRoleResource{}).Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %v", resp.Diagnostics)
+	}
+	return resp.Schema
+}
+
+// environmentRoleObject builds a complete object value for the resource schema,
+// filling attributes missing from known with fill.
+func environmentRoleObject(t *testing.T, s schema.Schema, known map[string]tftypes.Value, fill func(tftypes.Type) tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objectType, ok := s.Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected object type for schema, got %T", s.Type().TerraformType(context.Background()))
+	}
+
+	values := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+	for name, attributeType := range objectType.AttributeTypes {
+		if value, found := known[name]; found {
+			values[name] = value
+			continue
+		}
+		values[name] = fill(attributeType)
+	}
+
+	return tftypes.NewValue(objectType, values)
+}
+
+func unknownFill(attributeType tftypes.Type) tftypes.Value {
+	return tftypes.NewValue(attributeType, tftypes.UnknownValue)
+}
+
+func nullFill(attributeType tftypes.Type) tftypes.Value {
+	return tftypes.NewValue(attributeType, nil)
+}
+
+func environmentRolePermissionsValue(permissions ...string) tftypes.Value {
+	elements := make([]tftypes.Value, 0, len(permissions))
+	for _, permission := range permissions {
+		elements = append(elements, tftypes.NewValue(tftypes.String, permission))
+	}
+	return tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, elements)
+}
+
+// TestEnvironmentRoleResourceUpdate_PreservesUnmanagedPermissions covers the
+// environment role variant of
+// https://github.com/osodevops/terraform-provider-workos/issues/37. When
+// permissions are left out of the configuration they are Computed and planned
+// from prior state, so a name or description change must not rebuild them from
+// an update response that omits them.
+func TestEnvironmentRoleResourceUpdate_PreservesUnmanagedPermissions(t *testing.T) {
+	ctx := context.Background()
+	api, server := newEnvironmentRoleMockAPI(t)
+
+	api.seedRole(&client.EnvironmentRole{
+		ID:          "role_00000001",
+		Object:      "role",
+		Slug:        "billing-admin",
+		Name:        "Billing Admin",
+		Description: "Manages billing",
+		Type:        "EnvironmentRole",
+		Permissions: []string{"billing:read", "billing:write"},
+	})
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &EnvironmentRoleResource{client: workosClient}
+
+	s := environmentRoleSchema(t)
+	permissions := environmentRolePermissionsValue("billing:read", "billing:write")
+
+	known := map[string]tftypes.Value{
+		"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+		"slug":               tftypes.NewValue(tftypes.String, "billing-admin"),
+		"name":               tftypes.NewValue(tftypes.String, "Billing Admin"),
+		"description":        tftypes.NewValue(tftypes.String, "Manages billing"),
+		"type":               tftypes.NewValue(tftypes.String, "EnvironmentRole"),
+		"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+		"permissions":        permissions,
+		"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+		"updated_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+	}
+
+	priorState := tfsdk.State{Schema: s, Raw: environmentRoleObject(t, s, known, nullFill)}
+
+	planned := make(map[string]tftypes.Value, len(known))
+	for name, value := range known {
+		planned[name] = value
+	}
+	planned["description"] = tftypes.NewValue(tftypes.String, "Manages billing and invoices")
+	delete(planned, "updated_at")
+	plan := tfsdk.Plan{Schema: s, Raw: environmentRoleObject(t, s, planned, unknownFill)}
+
+	// permissions is absent from the configuration, so it is null there.
+	config := tfsdk.Config{Schema: s, Raw: environmentRoleObject(t, s, map[string]tftypes.Value{
+		"slug":        tftypes.NewValue(tftypes.String, "billing-admin"),
+		"name":        tftypes.NewValue(tftypes.String, "Billing Admin"),
+		"description": tftypes.NewValue(tftypes.String, "Manages billing and invoices"),
+	}, nullFill)}
+
+	resp := &fwresource.UpdateResponse{State: tfsdk.State{Schema: s, Raw: priorState.Raw}}
+	r.Update(ctx, fwresource.UpdateRequest{Plan: plan, State: priorState, Config: config}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned errors: %v", resp.Diagnostics)
+	}
+
+	var state EnvironmentRoleResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+
+	if state.Description.ValueString() != "Manages billing and invoices" {
+		t.Fatalf("expected the description change to be applied, got %v", state.Description)
+	}
+
+	var applied []string
+	if diags := state.Permissions.ElementsAs(ctx, &applied, false); diags.HasError() {
+		t.Fatalf("failed to read permissions: %v", diags)
+	}
+	if len(applied) != 2 {
+		t.Fatalf("expected permissions to survive the update, got %v", applied)
+	}
+}
+
+// TestEnvironmentRoleResourceUpdate_AppliesManagedPermissions guards the other
+// direction: when permissions are configured they are authoritative, and the
+// replace-all endpoint's response is what must land in state.
+func TestEnvironmentRoleResourceUpdate_AppliesManagedPermissions(t *testing.T) {
+	ctx := context.Background()
+	api, server := newEnvironmentRoleMockAPI(t)
+
+	api.seedRole(&client.EnvironmentRole{
+		ID:          "role_00000001",
+		Object:      "role",
+		Slug:        "billing-admin",
+		Name:        "Billing Admin",
+		Description: "Manages billing",
+		Type:        "EnvironmentRole",
+		Permissions: []string{"billing:read"},
+	})
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &EnvironmentRoleResource{client: workosClient}
+
+	s := environmentRoleSchema(t)
+
+	priorState := tfsdk.State{Schema: s, Raw: environmentRoleObject(t, s, map[string]tftypes.Value{
+		"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+		"slug":               tftypes.NewValue(tftypes.String, "billing-admin"),
+		"name":               tftypes.NewValue(tftypes.String, "Billing Admin"),
+		"description":        tftypes.NewValue(tftypes.String, "Manages billing"),
+		"type":               tftypes.NewValue(tftypes.String, "EnvironmentRole"),
+		"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+		"permissions":        environmentRolePermissionsValue("billing:read"),
+		"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+		"updated_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+	}, nullFill)}
+
+	newPermissions := environmentRolePermissionsValue("billing:read", "billing:write")
+
+	plan := tfsdk.Plan{Schema: s, Raw: environmentRoleObject(t, s, map[string]tftypes.Value{
+		"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+		"slug":               tftypes.NewValue(tftypes.String, "billing-admin"),
+		"name":               tftypes.NewValue(tftypes.String, "Billing Admin"),
+		"description":        tftypes.NewValue(tftypes.String, "Manages billing"),
+		"type":               tftypes.NewValue(tftypes.String, "EnvironmentRole"),
+		"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+		"permissions":        newPermissions,
+		"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+	}, unknownFill)}
+
+	config := tfsdk.Config{Schema: s, Raw: environmentRoleObject(t, s, map[string]tftypes.Value{
+		"slug":        tftypes.NewValue(tftypes.String, "billing-admin"),
+		"name":        tftypes.NewValue(tftypes.String, "Billing Admin"),
+		"description": tftypes.NewValue(tftypes.String, "Manages billing"),
+		"permissions": newPermissions,
+	}, nullFill)}
+
+	resp := &fwresource.UpdateResponse{State: tfsdk.State{Schema: s, Raw: priorState.Raw}}
+	r.Update(ctx, fwresource.UpdateRequest{Plan: plan, State: priorState, Config: config}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned errors: %v", resp.Diagnostics)
+	}
+
+	var state EnvironmentRoleResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+
+	var applied []string
+	if diags := state.Permissions.ElementsAs(ctx, &applied, false); diags.HasError() {
+		t.Fatalf("failed to read permissions: %v", diags)
+	}
+	if len(applied) != 2 {
+		t.Fatalf("expected the configured permissions to be applied, got %v", applied)
+	}
+}

--- a/internal/provider/resource_organization_role.go
+++ b/internal/provider/resource_organization_role.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -187,6 +188,16 @@ func (r *OrganizationRoleResource) Configure(ctx context.Context, req resource.C
 	r.client = client
 }
 
+// organizationRolePermissions converts the permission slugs returned by the API
+// into the list stored in state. Permissions are always represented as a list,
+// never null, so an unassigned role plans and applies consistently.
+func organizationRolePermissions(ctx context.Context, permissions []string) (types.List, diag.Diagnostics) {
+	if permissions == nil {
+		permissions = []string{}
+	}
+	return types.ListValueFrom(ctx, types.StringType, permissions)
+}
+
 func (r *OrganizationRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan OrganizationRoleResourceModel
 
@@ -238,17 +249,12 @@ func (r *OrganizationRoleResource) Create(ctx context.Context, req resource.Crea
 	plan.CreatedAt = types.StringValue(role.CreatedAt.Format(time.RFC3339))
 	plan.UpdatedAt = types.StringValue(role.UpdatedAt.Format(time.RFC3339))
 
-	// Map permissions - always set as empty list rather than null
-	if len(role.Permissions) > 0 {
-		permissions, diags := types.ListValueFrom(ctx, types.StringType, role.Permissions)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		plan.Permissions = permissions
-	} else {
-		plan.Permissions, _ = types.ListValueFrom(ctx, types.StringType, []string{})
+	permissions, diags := organizationRolePermissions(ctx, role.Permissions)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
+	plan.Permissions = permissions
 
 	tflog.Info(ctx, "Created organization role", map[string]any{
 		"id":   role.ID,
@@ -308,17 +314,12 @@ func (r *OrganizationRoleResource) Read(ctx context.Context, req resource.ReadRe
 	state.CreatedAt = types.StringValue(role.CreatedAt.Format(time.RFC3339))
 	state.UpdatedAt = types.StringValue(role.UpdatedAt.Format(time.RFC3339))
 
-	// Map permissions - always set as empty list rather than null
-	if len(role.Permissions) > 0 {
-		permissions, diags := types.ListValueFrom(ctx, types.StringType, role.Permissions)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		state.Permissions = permissions
-	} else {
-		state.Permissions, _ = types.ListValueFrom(ctx, types.StringType, []string{})
+	permissions, diags := organizationRolePermissions(ctx, role.Permissions)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
+	state.Permissions = permissions
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -378,16 +379,21 @@ func (r *OrganizationRoleResource) Update(ctx context.Context, req resource.Upda
 	plan.Description = types.StringValue(role.Description)
 	plan.UpdatedAt = types.StringValue(role.UpdatedAt.Format(time.RFC3339))
 
-	// Map permissions - always set as empty list rather than null
-	if len(role.Permissions) > 0 {
-		permissions, diags := types.ListValueFrom(ctx, types.StringType, role.Permissions)
+	// permissions is Computed with UseStateForUnknown, so Terraform plans it as
+	// the value already held in state. The update endpoint does not echo
+	// permissions back, so rebuilding the list from its response empties it and
+	// Terraform rejects the apply with ".permissions: element N has vanished".
+	// Carry the prior value forward instead; assignments are managed by
+	// workos_organization_role_permission, and any change made outside Terraform
+	// is picked up by the next refresh.
+	plan.Permissions = state.Permissions
+	if plan.Permissions.IsNull() || plan.Permissions.IsUnknown() {
+		permissions, diags := organizationRolePermissions(ctx, role.Permissions)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 		plan.Permissions = permissions
-	} else {
-		plan.Permissions, _ = types.ListValueFrom(ctx, types.StringType, []string{})
 	}
 
 	tflog.Info(ctx, "Updated organization role", map[string]any{

--- a/internal/provider/resource_organization_role_update_test.go
+++ b/internal/provider/resource_organization_role_update_test.go
@@ -1,0 +1,549 @@
+// Copyright (c) OSO DevOps
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/osodevops/terraform-provider-workos/internal/client"
+)
+
+// organizationRoleMockAPI is a minimal in-memory stand-in for the WorkOS
+// authorization API covering the endpoints the organization role resource, its
+// permission assignments, and the organization resource they hang off exercise.
+//
+// Its defining behaviour is that the role update endpoint does not echo
+// permissions back, exactly as the WorkOS API behaves. That omission is what
+// https://github.com/osodevops/terraform-provider-workos/issues/37 trips over.
+type organizationRoleMockAPI struct {
+	mu            sync.Mutex
+	counter       int
+	organizations map[string]*client.Organization
+	// roles is keyed by "<organization id>/<role slug>".
+	roles map[string]*client.OrganizationRole
+
+	// echoPermissionsOnUpdate makes the update endpoint return the role's
+	// permissions, as an API that returns the full resource would. WorkOS does
+	// not, so this defaults to false.
+	echoPermissionsOnUpdate bool
+}
+
+func newOrganizationRoleMockAPI(t *testing.T) (*organizationRoleMockAPI, *httptest.Server) {
+	t.Helper()
+
+	api := &organizationRoleMockAPI{
+		organizations: make(map[string]*client.Organization),
+		roles:         make(map[string]*client.OrganizationRole),
+	}
+	server := httptest.NewServer(api)
+	t.Cleanup(server.Close)
+
+	return api, server
+}
+
+func (a *organizationRoleMockAPI) nextID(prefix string) string {
+	a.counter++
+	return fmt.Sprintf("%s_%08d", prefix, a.counter)
+}
+
+// seedRole registers a role directly, for tests that drive the resource methods
+// without going through a create.
+func (a *organizationRoleMockAPI) seedRole(orgID string, role *client.OrganizationRole) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.roles[orgID+"/"+role.Slug] = role
+}
+
+func (a *organizationRoleMockAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	switch {
+	case r.URL.Path == "/organizations" && r.Method == http.MethodPost:
+		a.createOrganization(w, r)
+	case strings.HasPrefix(r.URL.Path, "/organizations/"):
+		a.organizationByID(w, r, strings.TrimPrefix(r.URL.Path, "/organizations/"))
+	case strings.HasPrefix(r.URL.Path, "/authorization/organizations/"):
+		a.authorization(w, r, strings.TrimPrefix(r.URL.Path, "/authorization/organizations/"))
+	default:
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+	}
+}
+
+func (a *organizationRoleMockAPI) createOrganization(w http.ResponseWriter, r *http.Request) {
+	var req client.OrganizationCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	org := &client.Organization{
+		ID:        a.nextID("org"),
+		Object:    "organization",
+		Name:      req.Name,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	a.organizations[org.ID] = org
+	writeJSON(w, http.StatusCreated, org)
+}
+
+func (a *organizationRoleMockAPI) organizationByID(w http.ResponseWriter, r *http.Request, id string) {
+	org, ok := a.organizations[id]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, org)
+	case http.MethodDelete:
+		delete(a.organizations, id)
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+// authorization routes the paths under /authorization/organizations/, which are
+// "<org id>/roles[/<slug>[/permissions[/<permission slug>]]]".
+func (a *organizationRoleMockAPI) authorization(w http.ResponseWriter, r *http.Request, rest string) {
+	parts := strings.Split(rest, "/")
+	if len(parts) < 2 || parts[1] != "roles" {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+	orgID := parts[0]
+
+	switch {
+	case len(parts) == 2 && r.Method == http.MethodPost:
+		a.createRole(w, r, orgID)
+	case len(parts) == 2 && r.Method == http.MethodGet:
+		a.listRoles(w, orgID)
+	case len(parts) == 3:
+		a.roleBySlug(w, r, orgID, parts[2])
+	case len(parts) == 4 && parts[3] == "permissions" && r.Method == http.MethodPost:
+		a.addPermission(w, r, orgID, parts[2])
+	case len(parts) == 5 && parts[3] == "permissions" && r.Method == http.MethodDelete:
+		a.removePermission(w, orgID, parts[2], parts[4])
+	default:
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+	}
+}
+
+func (a *organizationRoleMockAPI) createRole(w http.ResponseWriter, r *http.Request, orgID string) {
+	var req client.OrganizationRoleCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	role := &client.OrganizationRole{
+		ID:               a.nextID("role"),
+		Object:           "role",
+		Slug:             req.Slug,
+		Name:             req.Name,
+		Description:      req.Description,
+		Type:             "OrganizationRole",
+		Permissions:      []string{},
+		ResourceTypeSlug: req.ResourceTypeSlug,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	a.roles[orgID+"/"+role.Slug] = role
+	writeJSON(w, http.StatusCreated, role)
+}
+
+func (a *organizationRoleMockAPI) listRoles(w http.ResponseWriter, orgID string) {
+	resp := client.OrganizationRoleListResponse{Data: []client.OrganizationRole{}}
+	for key, role := range a.roles {
+		if strings.HasPrefix(key, orgID+"/") {
+			resp.Data = append(resp.Data, *role)
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (a *organizationRoleMockAPI) roleBySlug(w http.ResponseWriter, r *http.Request, orgID, slug string) {
+	key := orgID + "/" + slug
+	role, ok := a.roles[key]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, role)
+	case http.MethodPatch:
+		var req client.OrganizationRoleUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Name != "" {
+			role.Name = req.Name
+		}
+		role.Description = req.Description
+		role.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+		// WorkOS' update response omits the role's permissions. Reproduce that
+		// here so the provider is exercised against the real response shape.
+		response := *role
+		if !a.echoPermissionsOnUpdate {
+			response.Permissions = nil
+		}
+		writeJSON(w, http.StatusOK, response)
+	case http.MethodDelete:
+		delete(a.roles, key)
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		http.Error(w, `{"message":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *organizationRoleMockAPI) addPermission(w http.ResponseWriter, r *http.Request, orgID, slug string) {
+	role, ok := a.roles[orgID+"/"+slug]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	var req client.AddPermissionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"message":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+
+	for _, existing := range role.Permissions {
+		if existing == req.Slug {
+			writeJSON(w, http.StatusOK, role)
+			return
+		}
+	}
+	role.Permissions = append(role.Permissions, req.Slug)
+	writeJSON(w, http.StatusCreated, role)
+}
+
+func (a *organizationRoleMockAPI) removePermission(w http.ResponseWriter, orgID, slug, permission string) {
+	role, ok := a.roles[orgID+"/"+slug]
+	if !ok {
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+		return
+	}
+
+	remaining := make([]string, 0, len(role.Permissions))
+	for _, existing := range role.Permissions {
+		if existing != permission {
+			remaining = append(remaining, existing)
+		}
+	}
+	role.Permissions = remaining
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// organizationRoleSchema returns the resource schema under test.
+func organizationRoleSchema(t *testing.T) schema.Schema {
+	t.Helper()
+
+	resp := &fwresource.SchemaResponse{}
+	(&OrganizationRoleResource{}).Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %v", resp.Diagnostics)
+	}
+	return resp.Schema
+}
+
+// organizationRoleObject builds a complete object value for the resource
+// schema. Attributes missing from known are filled with unknown, matching the
+// plan Terraform hands a provider for Computed values it cannot predict.
+func organizationRoleObject(t *testing.T, s schema.Schema, known map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	objectType, ok := s.Type().TerraformType(context.Background()).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected object type for schema, got %T", s.Type().TerraformType(context.Background()))
+	}
+
+	values := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+	for name, attributeType := range objectType.AttributeTypes {
+		if value, found := known[name]; found {
+			values[name] = value
+			continue
+		}
+		values[name] = tftypes.NewValue(attributeType, tftypes.UnknownValue)
+	}
+
+	return tftypes.NewValue(objectType, values)
+}
+
+func organizationRolePermissionsList(permissions ...string) tftypes.Value {
+	elements := make([]tftypes.Value, 0, len(permissions))
+	for _, permission := range permissions {
+		elements = append(elements, tftypes.NewValue(tftypes.String, permission))
+	}
+	return tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, elements)
+}
+
+// TestOrganizationRoleResourceUpdate_PreservesAssignedPermissions reproduces
+// https://github.com/osodevops/terraform-provider-workos/issues/37: changing
+// name or description on a role that has permissions assigned dropped every
+// permission from state, because Update rebuilt the list from an update
+// response that never carries one. permissions is Computed with
+// UseStateForUnknown, so its planned value is the prior state value and
+// Terraform rejects any other applied value with "element N has vanished".
+func TestOrganizationRoleResourceUpdate_PreservesAssignedPermissions(t *testing.T) {
+	ctx := context.Background()
+	api, server := newOrganizationRoleMockAPI(t)
+
+	const orgID = "org_00000001"
+	api.seedRole(orgID, &client.OrganizationRole{
+		ID:          "role_00000001",
+		Object:      "role",
+		Slug:        "dealer-editor",
+		Name:        "Dealer Editor",
+		Description: "Edits dealers",
+		Type:        "OrganizationRole",
+		Permissions: []string{"dealer:read", "dealer:write"},
+	})
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &OrganizationRoleResource{client: workosClient}
+
+	s := organizationRoleSchema(t)
+	permissions := organizationRolePermissionsList("dealer:read", "dealer:write")
+
+	priorState := tfsdk.State{
+		Schema: s,
+		Raw: organizationRoleObject(t, s, map[string]tftypes.Value{
+			"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+			"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+			"slug":               tftypes.NewValue(tftypes.String, "dealer-editor"),
+			"name":               tftypes.NewValue(tftypes.String, "Dealer Editor"),
+			"description":        tftypes.NewValue(tftypes.String, "Edits dealers"),
+			"type":               tftypes.NewValue(tftypes.String, "OrganizationRole"),
+			"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+			"permissions":        permissions,
+			"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+			"updated_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+		}),
+	}
+
+	// The plan Terraform produces for a description change: permissions keeps
+	// the prior state value via UseStateForUnknown, updated_at is unknown.
+	plan := tfsdk.Plan{
+		Schema: s,
+		Raw: organizationRoleObject(t, s, map[string]tftypes.Value{
+			"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+			"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+			"slug":               tftypes.NewValue(tftypes.String, "dealer-editor"),
+			"name":               tftypes.NewValue(tftypes.String, "Dealer Editor"),
+			"description":        tftypes.NewValue(tftypes.String, "Edits dealers and their staff"),
+			"type":               tftypes.NewValue(tftypes.String, "OrganizationRole"),
+			"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+			"permissions":        permissions,
+			"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+		}),
+	}
+
+	resp := &fwresource.UpdateResponse{State: tfsdk.State{Schema: s, Raw: priorState.Raw}}
+	r.Update(ctx, fwresource.UpdateRequest{Plan: plan, State: priorState}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned errors: %v", resp.Diagnostics)
+	}
+
+	var state OrganizationRoleResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+
+	if state.Description.ValueString() != "Edits dealers and their staff" {
+		t.Fatalf("expected the description change to be applied, got %v", state.Description)
+	}
+
+	var applied []string
+	if diags := state.Permissions.ElementsAs(ctx, &applied, false); diags.HasError() {
+		t.Fatalf("failed to read permissions: %v", diags)
+	}
+	if len(applied) != 2 || applied[0] != "dealer:read" || applied[1] != "dealer:write" {
+		t.Fatalf("expected permissions to survive the update, got %v", applied)
+	}
+}
+
+// TestOrganizationRoleResourceUpdate_KeepsEmptyPermissions covers the role with
+// no permissions assigned: the applied value must stay an empty list, never
+// null, so the value still matches the planned one.
+func TestOrganizationRoleResourceUpdate_KeepsEmptyPermissions(t *testing.T) {
+	ctx := context.Background()
+	api, server := newOrganizationRoleMockAPI(t)
+
+	const orgID = "org_00000001"
+	api.seedRole(orgID, &client.OrganizationRole{
+		ID:          "role_00000001",
+		Object:      "role",
+		Slug:        "dealer-viewer",
+		Name:        "Dealer Viewer",
+		Type:        "OrganizationRole",
+		Permissions: []string{},
+	})
+
+	workosClient, err := client.NewClient("sk_test", "", server.URL)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	r := &OrganizationRoleResource{client: workosClient}
+
+	s := organizationRoleSchema(t)
+	empty := organizationRolePermissionsList()
+
+	priorState := tfsdk.State{
+		Schema: s,
+		Raw: organizationRoleObject(t, s, map[string]tftypes.Value{
+			"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+			"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+			"slug":               tftypes.NewValue(tftypes.String, "dealer-viewer"),
+			"name":               tftypes.NewValue(tftypes.String, "Dealer Viewer"),
+			"description":        tftypes.NewValue(tftypes.String, ""),
+			"type":               tftypes.NewValue(tftypes.String, "OrganizationRole"),
+			"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+			"permissions":        empty,
+			"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+			"updated_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+		}),
+	}
+
+	plan := tfsdk.Plan{
+		Schema: s,
+		Raw: organizationRoleObject(t, s, map[string]tftypes.Value{
+			"id":                 tftypes.NewValue(tftypes.String, "role_00000001"),
+			"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+			"slug":               tftypes.NewValue(tftypes.String, "dealer-viewer"),
+			"name":               tftypes.NewValue(tftypes.String, "Dealer Viewer Renamed"),
+			"description":        tftypes.NewValue(tftypes.String, ""),
+			"type":               tftypes.NewValue(tftypes.String, "OrganizationRole"),
+			"resource_type_slug": tftypes.NewValue(tftypes.String, nil),
+			"permissions":        empty,
+			"created_at":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+		}),
+	}
+
+	resp := &fwresource.UpdateResponse{State: tfsdk.State{Schema: s, Raw: priorState.Raw}}
+	r.Update(ctx, fwresource.UpdateRequest{Plan: plan, State: priorState}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned errors: %v", resp.Diagnostics)
+	}
+
+	var state OrganizationRoleResourceModel
+	if diags := resp.State.Get(ctx, &state); diags.HasError() {
+		t.Fatalf("failed to read resulting state: %v", diags)
+	}
+
+	if state.Permissions.IsNull() || state.Permissions.IsUnknown() {
+		t.Fatalf("expected permissions to be a known empty list, got %v", state.Permissions)
+	}
+	if len(state.Permissions.Elements()) != 0 {
+		t.Fatalf("expected permissions to stay empty, got %v", state.Permissions)
+	}
+}
+
+// TestAccOrganizationRoleResource_UpdateWithPermissionsMockAPI drives the whole
+// scenario from issue #37 through Terraform against the mock WorkOS API, so
+// Terraform's own post-apply consistency check is what proves the fix.
+// Requires the Terraform CLI.
+func TestAccOrganizationRoleResource_UpdateWithPermissionsMockAPI(t *testing.T) {
+	_, server := newOrganizationRoleMockAPI(t)
+
+	t.Setenv("WORKOS_API_KEY", "sk_test")
+	t.Setenv("WORKOS_BASE_URL", server.URL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create the role and assign two permissions to it.
+			{
+				Config: testAccOrganizationRoleWithPermissionsMockConfig(server.URL, "Edits dealers"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "slug", "dealer-editor"),
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "description", "Edits dealers"),
+				),
+			},
+			// Re-apply unchanged so the refreshed state carries the assigned
+			// permissions, which is the state the update then has to preserve.
+			{
+				Config: testAccOrganizationRoleWithPermissionsMockConfig(server.URL, "Edits dealers"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "permissions.#", "2"),
+				),
+			},
+			// Change the description. Before the fix this failed with
+			// "Provider produced inconsistent result after apply ...
+			// .permissions: element 0 has vanished".
+			{
+				Config: testAccOrganizationRoleWithPermissionsMockConfig(server.URL, "Edits dealers and their staff"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "description", "Edits dealers and their staff"),
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "permissions.#", "2"),
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "permissions.0", "dealer:read"),
+					resource.TestCheckResourceAttr("workos_organization_role.dealer_editor", "permissions.1", "dealer:write"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrganizationRoleWithPermissionsMockConfig(baseURL, description string) string {
+	return fmt.Sprintf(`
+provider "workos" {
+  api_key  = "sk_test"
+  base_url = %[1]q
+}
+
+resource "workos_organization" "test" {
+  name = "Example Dealer Group"
+}
+
+resource "workos_organization_role" "dealer_editor" {
+  organization_id    = workos_organization.test.id
+  slug               = "dealer-editor"
+  name               = "Dealer Editor"
+  description        = %[2]q
+  resource_type_slug = "dealer"
+}
+
+resource "workos_organization_role_permission" "read" {
+  organization_id = workos_organization.test.id
+  role_slug       = workos_organization_role.dealer_editor.slug
+  permission      = "dealer:read"
+}
+
+resource "workos_organization_role_permission" "write" {
+  organization_id = workos_organization.test.id
+  role_slug       = workos_organization_role.dealer_editor.slug
+  permission      = "dealer:write"
+
+  depends_on = [workos_organization_role_permission.read]
+}
+`, baseURL, description)
+}


### PR DESCRIPTION
Fixes #37

## Problem

Updating `name` or `description` on a `workos_organization_role` that has permissions assigned fails the apply with one error per assigned permission:

```
Error: Provider produced inconsistent result after apply

When applying changes to workos_organization_role.roles["dealer_editor"],
provider "provider[\"registry.terraform.io/osodevops/workos\"]" produced an
unexpected new value: .permissions: element 0 has vanished.
```

The role update itself reaches WorkOS successfully — the failure is Terraform's post-apply consistency check, leaving the resource errored-but-partially-applied on every such change.

## Root cause

`permissions` is Computed with `UseStateForUnknown`, so Terraform plans it as the value already held in state. `Update` rebuilt the list from the `UpdateOrganizationRole` response, which does not carry permissions, and so wrote an empty list that no longer matched the plan. The permissions were never actually removed at WorkOS.

`Update` already had a "nothing changed" fast path that correctly did `plan.Permissions = state.Permissions`; only the real update path was affected.

## Fix

`Update` carries the prior permissions forward rather than deriving them from the update response. Per [HashiCorp's plan-modification guidance](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification), preserving prior state is the correct handling for a Computed attribute with `UseStateForUnknown` that the update endpoint does not echo back; a change made outside Terraform is still picked up by the next refresh.

`workos_environment_role` had the same defect on the path where `permissions` is not managed in configuration, and gets the same treatment. When `permissions` **is** configured it stays authoritative — the replace-all endpoint's response still wins.

The duplicated "always a list, never null" permission mapping in `Create`/`Read`/`Update` is now a single `organizationRolePermissions` helper, matching the existing `environment_role_helpers.go` style.

## Tests

Written first, confirmed failing against the unfixed code:

- `TestOrganizationRoleResourceUpdate_PreservesAssignedPermissions` — drives `Update` against a mock WorkOS API whose update endpoint omits permissions. Failed with `got []`.
- `TestOrganizationRoleResourceUpdate_KeepsEmptyPermissions` — a role with no permissions keeps a known empty list, never null.
- `TestAccOrganizationRoleResource_UpdateWithPermissionsMockAPI` — full Terraform apply against the mock, so Terraform's own consistency check is what proves the fix. Reproduced the reported error verbatim:
  ```
  Error: Provider produced inconsistent result after apply
  ... produced an unexpected new value: .permissions: element 0 has vanished.
  ... produced an unexpected new value: .permissions: element 1 has vanished.
  ```
- `TestEnvironmentRoleResourceUpdate_PreservesUnmanagedPermissions` — environment role variant. Failed with `got []`.
- `TestEnvironmentRoleResourceUpdate_AppliesManagedPermissions` — guards that configured permissions are still authoritative. Passed before and after.

All five pass after the fix; `go test ./...`, `go vet ./...` and `go generate ./...` (no doc drift) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jsFi8erY2XwAcoHfgGhJ8